### PR TITLE
fix: token refresh 로직 수정 MZ-161

### DIFF
--- a/src/main/kotlin/com/oksusu/susu/auth/model/dto/response/TokenRefreshRequest.kt
+++ b/src/main/kotlin/com/oksusu/susu/auth/model/dto/response/TokenRefreshRequest.kt
@@ -1,5 +1,6 @@
 package com.oksusu.susu.auth.model.dto.response
 
 data class TokenRefreshRequest(
+    val accessToken: String,
     val refreshToken: String,
 )

--- a/src/main/kotlin/com/oksusu/susu/auth/presentation/AuthResource.kt
+++ b/src/main/kotlin/com/oksusu/susu/auth/presentation/AuthResource.kt
@@ -30,9 +30,8 @@ class AuthResource(
     @Operation(summary = "token refresh")
     @PostMapping("/token/refresh")
     suspend fun tokenRefresh(
-        authUser: AuthUser,
         @RequestBody request: TokenRefreshRequest,
-    ) = authFacade.refreshToken(authUser, request).wrapOk()
+    ) = authFacade.refreshToken(request).wrapOk()
 
     /** 회원 탈퇴 */
     @Operation(summary = "withdraw")

--- a/src/main/kotlin/com/oksusu/susu/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/oksusu/susu/exception/ErrorCode.kt
@@ -15,8 +15,9 @@ enum class ErrorCode(val status: HttpStatus, val description: String) {
 
     /** Auth Error Code */
     FAIL_TO_VERIFY_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "fail to verify token"),
-    NOT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 아닙니다."),
-    NOT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 아닙니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 엑세스 토큰이 아닙니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰이 아닙니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효한 토큰이 아닙니다."),
 
     /** User Error Code */
     USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## 작업사항
- 토큰 리프레시 로직 수정했습니다.

## 변경로직
- 안드에서 401 에러 받으면 토큰 리프레시 로직 실행된다고 해서, 리프레시 중 발생하는 에러는 400 으로 구현했습니다..
